### PR TITLE
Add /opt/local dirs to libheif_build.py

### DIFF
--- a/libheif/libheif_build.py
+++ b/libheif/libheif_build.py
@@ -12,8 +12,8 @@ ffibuilder.set_source(
     """
      #include "libheif/heif.h"
     """,
-    include_dirs=["/usr/local/include", "/usr/include"],
-    library_dirs=["/usr/local/lib", "/usr/lib", "/lib"],
+    include_dirs=["/usr/local/include", "/usr/include", "/opt/local/include"],
+    library_dirs=["/usr/local/lib", "/usr/lib", "/lib", "/opt/local/lib"],
     libraries=["heif"],
 )
 


### PR DESCRIPTION
This enables out of the box MacPorts builds.

Closes: https://github.com/carsales/pyheif/issues/32