### PR TITLE
Find homebrew folder

### DIFF
--- a/libheif/libheif_build.py
+++ b/libheif/libheif_build.py
@@ -7,13 +7,21 @@ ffibuilder = FFI()
 with open("libheif/heif.h") as f:
     ffibuilder.cdef(f.read())
 
+include_dirs = ["/usr/local/include", "/usr/include", "/opt/local/include"]
+library_dirs = ["/usr/local/lib", "/usr/lib", "/lib", "/opt/local/lib"]
+
+homebrew_path = os.getenv('HOMEBREW_PREFIX')
+if homebrew_path:
+    include_dirs.append(os.path.join(homebrew_path, "include"))
+    library_dirs.append(os.path.join(homebrew_path, "lib"))
+
 ffibuilder.set_source(
     "_libheif_cffi",
     """
      #include "libheif/heif.h"
     """,
-    include_dirs=["/usr/local/include", "/usr/include", "/opt/local/include"],
-    library_dirs=["/usr/local/lib", "/usr/lib", "/lib", "/opt/local/lib"],
+    include_dirs=include_dirs,
+    library_dirs=library_dirs,
     libraries=["heif"],
 )
 


### PR DESCRIPTION
Hello,

Failing to build libheif on macos with error:
```
build/temp.macosx-11-universal2-3.8/_libheif_cffi.c:570:15: fatal error: 'libheif/heif.h' file not found
         #include "libheif/heif.h"
                  ^~~~~~~~~~~~~~~~
    1 error generated.
    error: command 'gcc' failed with exit status 1
```

Looks like the same issue as https://github.com/carsales/pyheif/issues/36

My homebrew folder is `/opt/homebrew`, tried with the following change and worked fine. Let me know what you think.

Thanks!