### PR TITLE
Return ffi.buffer as data to avoid extra memory copying

### DIFF
--- a/pyheif/reader.py
+++ b/pyheif/reader.py
@@ -125,7 +125,8 @@ def _read_heif_handle(handle, apply_transformations, convert_hdr_to_8bit):
 
     p_options = _libheif_cffi.lib.heif_decoding_options_alloc()
     p_options = _libheif_cffi.ffi.gc(
-        p_options, _libheif_cffi.lib.heif_decoding_options_free)
+        p_options, _libheif_cffi.lib.heif_decoding_options_free
+    )
     p_options.ignore_transformations = int(not apply_transformations)
     p_options.convert_hdr_to_8bit = int(convert_hdr_to_8bit)
 

--- a/pyheif/reader.py
+++ b/pyheif/reader.py
@@ -124,17 +124,15 @@ def _read_heif_handle(handle, apply_transformations, convert_hdr_to_8bit):
             chroma = _constants.heif_chroma_interleaved_RRGGBB_BE
 
     p_options = _libheif_cffi.lib.heif_decoding_options_alloc()
-    try:
-        p_options.ignore_transformations = int(not apply_transformations)
-        p_options.convert_hdr_to_8bit = int(convert_hdr_to_8bit)
+    p_options = _libheif_cffi.ffi.gc(
+        p_options, _libheif_cffi.lib.heif_decoding_options_free)
+    p_options.ignore_transformations = int(not apply_transformations)
+    p_options.convert_hdr_to_8bit = int(convert_hdr_to_8bit)
 
-        p_img = _libheif_cffi.ffi.new("struct heif_image **")
-        error = _libheif_cffi.lib.heif_decode_image(
-            handle, p_img, colorspace, chroma, p_options,
-        )
-    finally:
-        _libheif_cffi.lib.heif_decoding_options_free(p_options)
-
+    p_img = _libheif_cffi.ffi.new("struct heif_image **")
+    error = _libheif_cffi.lib.heif_decode_image(
+        handle, p_img, colorspace, chroma, p_options,
+    )
     if error.code != 0:
         raise _error.HeifError(
             code=error.code,


### PR DESCRIPTION
This saves 3-7% time depending on number of cores.

master:
```python
$ python -m timeit -n5 -r10 -s "import pyheif; data = open('./full.norot.heic', 'rb').read()" "im = pyheif.read(data)"
5 loops, best of 10: 345 msec per loop
```

avoid-copy:
```python
$ python -m timeit -n5 -r10 -s "import pyheif; data = open('./full.norot.heic', 'rb').read()" "im = pyheif.read(data)"
5 loops, best of 10: 323 msec per loop
```

Also this makes `data` writable buffer, which avoid one more copy in such cases:

master:
```python
In [1]: import pyheif, numpy
In [2]: im = pyheif.read('./full.norot.heic')
In [3]: buf = numpy.frombuffer(im.data, dtype=numpy.uint8)
In [4]: buf[0:3] = b'123'
ValueError: assignment destination is read-only

In [5]: buf = buf.copy()
In [6]: buf[0:3] = b'123'  # now this works
```

avoid-copy:
```python
In [1]: import pyheif, numpy
In [2]: im = pyheif.read('./full.norot.heic')
In [3]: buf = numpy.frombuffer(im.data, dtype=numpy.uint8)
In [4]: buf[0:3] = b'123'
```