### PR TITLE
Separate open and load functions

### DIFF
--- a/pyheif/__init__.py
+++ b/pyheif/__init__.py
@@ -1,3 +1,4 @@
+import builtins
 import os
 
 import _libheif_cffi
@@ -7,7 +8,7 @@ from .reader import *
 from .writer import *
 
 version_path = os.path.dirname(os.path.abspath(__file__)) + "/data/version.txt"
-with open(version_path) as f:
+with builtins.open(version_path) as f:
     __version__ = f.read().strip()
 
 

--- a/pyheif/reader.py
+++ b/pyheif/reader.py
@@ -28,7 +28,7 @@ class HeifFile:
         )
 
     def load(self):
-        pass  # already loaded
+        return self  # already loaded
 
     def close(self):
         pass  # TODO: release self.data here?

--- a/pyheif/reader.py
+++ b/pyheif/reader.py
@@ -8,16 +8,15 @@ from . import error as _error
 
 
 class HeifFile:
-    def __init__(
-        self, *, size, data, metadata, color_profile, has_alpha, bit_depth, stride
-    ):
+    def __init__(self, *, size, has_alpha, bit_depth,
+                 metadata=None, color_profile=None, data=None, stride=None):
         self.size = size
-        self.data = data
-        self.metadata = metadata
-        self.color_profile = color_profile
         self.has_alpha = has_alpha
         self.mode = "RGBA" if has_alpha else "RGB"
         self.bit_depth = bit_depth
+        self.metadata = metadata
+        self.color_profile = color_profile
+        self.data = data
         self.stride = stride
 
 
@@ -107,8 +106,6 @@ def _read_heif_context(ctx, d, apply_transformations, convert_hdr_to_8bit):
 def _read_heif_handle(handle, apply_transformations, convert_hdr_to_8bit):
     width = _libheif_cffi.lib.heif_image_handle_get_width(handle)
     height = _libheif_cffi.lib.heif_image_handle_get_height(handle)
-    size = (width, height)
-
     has_alpha = bool(_libheif_cffi.lib.heif_image_handle_has_alpha_channel(handle))
     bit_depth = _libheif_cffi.lib.heif_image_handle_get_luma_bits_per_pixel(handle)
     colorspace = _constants.heif_colorspace_RGB
@@ -141,19 +138,17 @@ def _read_heif_handle(handle, apply_transformations, convert_hdr_to_8bit):
         )
     img = p_img[0]
 
-    data, stride = _read_heif_image(img, height)
     metadata = _read_metadata(handle)
     color_profile = _read_color_profile(handle)
 
     heif_file = HeifFile(
-        size=size,
-        data=data,
-        metadata=metadata,
-        color_profile=color_profile,
+        size=(width, height),
         has_alpha=has_alpha,
         bit_depth=bit_depth,
-        stride=stride,
+        metadata=metadata,
+        color_profile=color_profile,
     )
+    heif_file.data, heif_file.stride = _read_heif_image(img, height)
     return heif_file
 
 

--- a/pyheif/reader.py
+++ b/pyheif/reader.py
@@ -20,6 +20,12 @@ class HeifFile:
         self.data = data
         self.stride = stride
 
+    def __repr__(self):
+        return (
+            f"<{self.__class__.__name__} {self.size[0]}x{self.size[1]} {self.mode} "
+            f"with {str(len(self.data)) + ' bytes' if self.data else 'no'} data>"
+        )
+
     def load(self):
         pass  # already loaded
 

--- a/pyheif/reader.py
+++ b/pyheif/reader.py
@@ -1,3 +1,4 @@
+import builtins
 import functools
 import pathlib
 import warnings
@@ -9,7 +10,7 @@ from . import error as _error
 
 class HeifFile:
     def __init__(self, *, size, has_alpha, bit_depth,
-                 metadata=None, color_profile=None, data=None, stride=None):
+                 metadata, color_profile, data, stride):
         self.size = size
         self.has_alpha = has_alpha
         self.mode = "RGBA" if has_alpha else "RGB"
@@ -18,6 +19,27 @@ class HeifFile:
         self.color_profile = color_profile
         self.data = data
         self.stride = stride
+
+    def load(self):
+        pass  # already loaded
+
+
+class UndecodedHeifFile(HeifFile):
+    def __init__(self, heif_handle, *,
+                 apply_transformations, convert_hdr_to_8bit, **kwargs):
+        self._heif_handle = heif_handle
+        self.apply_transformations = apply_transformations
+        self.convert_hdr_to_8bit = convert_hdr_to_8bit
+        super().__init__(data=None, stride=None, **kwargs)
+
+    def load(self):
+        self.data, self.stride = _read_heif_image(self._heif_handle, self)
+        self.__exit__()
+        self.__class__ = HeifFile
+        return self
+
+    def __exit__(self, *args):
+        del self._heif_handle
 
 
 def check(fp):
@@ -35,12 +57,17 @@ def read_heif(fp, apply_transformations=True):
 def read(fp, *, apply_transformations=True, convert_hdr_to_8bit=True):
     d = _get_bytes(fp)
     result = _read_heif_bytes(d, apply_transformations, convert_hdr_to_8bit)
-    return result
+    return result.load()
+
+
+def open(fp, *, apply_transformations=True, convert_hdr_to_8bit=True):
+    d = _get_bytes(fp)
+    return _read_heif_bytes(d, apply_transformations, convert_hdr_to_8bit)
 
 
 def _get_bytes(fp):
     if isinstance(fp, str):
-        with open(fp, "rb") as f:
+        with builtins.open(fp, "rb") as f:
             d = f.read()
     elif isinstance(fp, bytearray):
         d = bytes(fp)
@@ -68,11 +95,8 @@ def _read_heif_bytes(d, apply_transformations, convert_hdr_to_8bit):
         warnings.warn("Input is an unsupported HEIF/AVIF file type - trying anyway!")
 
     ctx = _libheif_cffi.lib.heif_context_alloc()
-    try:
-        result = _read_heif_context(ctx, d, apply_transformations, convert_hdr_to_8bit)
-    finally:
-        _libheif_cffi.lib.heif_context_free(ctx)
-    return result
+    ctx = _libheif_cffi.ffi.gc(ctx, _libheif_cffi.lib.heif_context_free)
+    return _read_heif_context(ctx, d, apply_transformations, convert_hdr_to_8bit)
 
 
 def _read_heif_context(ctx, d, apply_transformations, convert_hdr_to_8bit):
@@ -94,13 +118,10 @@ def _read_heif_context(ctx, d, apply_transformations, convert_hdr_to_8bit):
             subcode=error.subcode,
             message=_libheif_cffi.ffi.string(error.message).decode(),
         )
-    handle = p_handle[0]
+    handle = _libheif_cffi.ffi.gc(
+        p_handle[0], _libheif_cffi.lib.heif_image_handle_release)
 
-    try:
-        result = _read_heif_handle(handle, apply_transformations, convert_hdr_to_8bit)
-    finally:
-        _libheif_cffi.lib.heif_image_handle_release(handle)
-    return result
+    return _read_heif_handle(handle, apply_transformations, convert_hdr_to_8bit)
 
 
 def _read_heif_handle(handle, apply_transformations, convert_hdr_to_8bit):
@@ -112,15 +133,16 @@ def _read_heif_handle(handle, apply_transformations, convert_hdr_to_8bit):
     metadata = _read_metadata(handle)
     color_profile = _read_color_profile(handle)
 
-    heif_file = HeifFile(
+    heif_file = UndecodedHeifFile(
+        handle,
         size=(width, height),
         has_alpha=has_alpha,
         bit_depth=bit_depth,
         metadata=metadata,
         color_profile=color_profile,
+        apply_transformations=apply_transformations,
+        convert_hdr_to_8bit=convert_hdr_to_8bit,
     )
-    heif_file.data, heif_file.stride = _read_heif_image(
-        handle, heif_file, apply_transformations, convert_hdr_to_8bit)
     return heif_file
 
 
@@ -190,9 +212,9 @@ def _read_color_profile(handle):
     return color_profile
 
 
-def _read_heif_image(handle, heif_file, apply_transformations, convert_hdr_to_8bit):
+def _read_heif_image(handle, heif_file):
     colorspace = _constants.heif_colorspace_RGB
-    if convert_hdr_to_8bit or heif_file.bit_depth <= 8:
+    if heif_file.convert_hdr_to_8bit or heif_file.bit_depth <= 8:
         if heif_file.has_alpha:
             chroma = _constants.heif_chroma_interleaved_RGBA
         else:
@@ -206,8 +228,8 @@ def _read_heif_image(handle, heif_file, apply_transformations, convert_hdr_to_8b
     p_options = _libheif_cffi.lib.heif_decoding_options_alloc()
     p_options = _libheif_cffi.ffi.gc(
         p_options, _libheif_cffi.lib.heif_decoding_options_free)
-    p_options.ignore_transformations = int(not apply_transformations)
-    p_options.convert_hdr_to_8bit = int(convert_hdr_to_8bit)
+    p_options.ignore_transformations = int(not heif_file.apply_transformations)
+    p_options.convert_hdr_to_8bit = int(heif_file.convert_hdr_to_8bit)
 
     p_img = _libheif_cffi.ffi.new("struct heif_image **")
     error = _libheif_cffi.lib.heif_decode_image(

--- a/pyheif/reader.py
+++ b/pyheif/reader.py
@@ -9,8 +9,9 @@ from . import error as _error
 
 
 class HeifFile:
-    def __init__(self, *, size, has_alpha, bit_depth,
-                 metadata, color_profile, data, stride):
+    def __init__(
+        self, *, size, has_alpha, bit_depth, metadata, color_profile, data, stride
+    ):
         self.size = size
         self.has_alpha = has_alpha
         self.mode = "RGBA" if has_alpha else "RGB"
@@ -34,8 +35,9 @@ class HeifFile:
 
 
 class UndecodedHeifFile(HeifFile):
-    def __init__(self, heif_handle, *,
-                 apply_transformations, convert_hdr_to_8bit, **kwargs):
+    def __init__(
+        self, heif_handle, *, apply_transformations, convert_hdr_to_8bit, **kwargs
+    ):
         self._heif_handle = heif_handle
         self.apply_transformations = apply_transformations
         self.convert_hdr_to_8bit = convert_hdr_to_8bit
@@ -49,7 +51,7 @@ class UndecodedHeifFile(HeifFile):
 
     def close(self):
         # Don't call super().close() here, we don't need to free bytes.
-        if hasattr(self, '_heif_handle'):
+        if hasattr(self, "_heif_handle"):
             del self._heif_handle
 
 
@@ -66,8 +68,11 @@ def read_heif(fp, apply_transformations=True):
 
 
 def read(fp, *, apply_transformations=True, convert_hdr_to_8bit=True):
-    heif_file = open(fp, apply_transformations=apply_transformations,
-                     convert_hdr_to_8bit=convert_hdr_to_8bit)
+    heif_file = open(
+        fp,
+        apply_transformations=apply_transformations,
+        convert_hdr_to_8bit=convert_hdr_to_8bit,
+    )
     return heif_file.load()
 
 
@@ -102,8 +107,10 @@ def _keep_refs(destructor, **refs):
     Keep refs to passed arguments until `inner` callback exist.
     This prevents collecting parent objects until all children collcted.
     """
+
     def inner(cdata):
         return destructor(cdata)
+
     inner._refs = refs
     return inner
 
@@ -249,7 +256,8 @@ def _read_heif_image(handle, heif_file):
 
     p_options = _libheif_cffi.lib.heif_decoding_options_alloc()
     p_options = _libheif_cffi.ffi.gc(
-        p_options, _libheif_cffi.lib.heif_decoding_options_free)
+        p_options, _libheif_cffi.lib.heif_decoding_options_free
+    )
     p_options.ignore_transformations = int(not heif_file.apply_transformations)
     p_options.convert_hdr_to_8bit = int(heif_file.convert_hdr_to_8bit)
 
@@ -267,7 +275,8 @@ def _read_heif_image(handle, heif_file):
 
     p_stride = _libheif_cffi.ffi.new("int *")
     p_data = _libheif_cffi.lib.heif_image_get_plane_readonly(
-        img, _constants.heif_channel_interleaved, p_stride)
+        img, _constants.heif_channel_interleaved, p_stride
+    )
     stride = p_stride[0]
 
     data_length = heif_file.size[1] * stride

--- a/pyheif/reader.py
+++ b/pyheif/reader.py
@@ -86,6 +86,17 @@ def _get_bytes(fp):
     return d
 
 
+def _keep_refs(destructor, **refs):
+    """
+    Keep refs to passed arguments until `inner` callback exist.
+    This prevents collecting parent objects until all children collcted.
+    """
+    def inner(cdata):
+        return destructor(cdata)
+    inner._refs = refs
+    return inner
+
+
 def _read_heif_bytes(d, apply_transformations, convert_hdr_to_8bit):
     magic = d[:12]
     filetype_check = _libheif_cffi.lib.heif_check_filetype(magic, len(magic))
@@ -95,7 +106,8 @@ def _read_heif_bytes(d, apply_transformations, convert_hdr_to_8bit):
         warnings.warn("Input is an unsupported HEIF/AVIF file type - trying anyway!")
 
     ctx = _libheif_cffi.lib.heif_context_alloc()
-    ctx = _libheif_cffi.ffi.gc(ctx, _libheif_cffi.lib.heif_context_free)
+    collect = _keep_refs(_libheif_cffi.lib.heif_context_free, data=d)
+    ctx = _libheif_cffi.ffi.gc(ctx, collect)
     return _read_heif_context(ctx, d, apply_transformations, convert_hdr_to_8bit)
 
 
@@ -118,9 +130,8 @@ def _read_heif_context(ctx, d, apply_transformations, convert_hdr_to_8bit):
             subcode=error.subcode,
             message=_libheif_cffi.ffi.string(error.message).decode(),
         )
-    handle = _libheif_cffi.ffi.gc(
-        p_handle[0], _libheif_cffi.lib.heif_image_handle_release)
-
+    collect = _keep_refs(_libheif_cffi.lib.heif_image_handle_release, ctx=ctx)
+    handle = _libheif_cffi.ffi.gc(p_handle[0], collect)
     return _read_heif_handle(handle, apply_transformations, convert_hdr_to_8bit)
 
 
@@ -245,8 +256,7 @@ def _read_heif_image(handle, heif_file):
 
     p_stride = _libheif_cffi.ffi.new("int *")
     p_data = _libheif_cffi.lib.heif_image_get_plane_readonly(
-        img, _constants.heif_channel_interleaved, p_stride
-    )
+        img, _constants.heif_channel_interleaved, p_stride)
     stride = p_stride[0]
 
     data_length = heif_file.size[1] * stride

--- a/pyheif/reader.py
+++ b/pyheif/reader.py
@@ -40,12 +40,9 @@ class UndecodedHeifFile(HeifFile):
 
     def load(self):
         self.data, self.stride = _read_heif_image(self._heif_handle, self)
-        self.__exit__()
+        del self._heif_handle
         self.__class__ = HeifFile
         return self
-
-    def __exit__(self, *args):
-        del self._heif_handle
 
 
 def check(fp):

--- a/pyheif/reader.py
+++ b/pyheif/reader.py
@@ -108,35 +108,6 @@ def _read_heif_handle(handle, apply_transformations, convert_hdr_to_8bit):
     height = _libheif_cffi.lib.heif_image_handle_get_height(handle)
     has_alpha = bool(_libheif_cffi.lib.heif_image_handle_has_alpha_channel(handle))
     bit_depth = _libheif_cffi.lib.heif_image_handle_get_luma_bits_per_pixel(handle)
-    colorspace = _constants.heif_colorspace_RGB
-    if convert_hdr_to_8bit or bit_depth <= 8:
-        if has_alpha:
-            chroma = _constants.heif_chroma_interleaved_RGBA
-        else:
-            chroma = _constants.heif_chroma_interleaved_RGB
-    else:
-        if has_alpha:
-            chroma = _constants.heif_chroma_interleaved_RRGGBBAA_BE
-        else:
-            chroma = _constants.heif_chroma_interleaved_RRGGBB_BE
-
-    p_options = _libheif_cffi.lib.heif_decoding_options_alloc()
-    p_options = _libheif_cffi.ffi.gc(
-        p_options, _libheif_cffi.lib.heif_decoding_options_free)
-    p_options.ignore_transformations = int(not apply_transformations)
-    p_options.convert_hdr_to_8bit = int(convert_hdr_to_8bit)
-
-    p_img = _libheif_cffi.ffi.new("struct heif_image **")
-    error = _libheif_cffi.lib.heif_decode_image(
-        handle, p_img, colorspace, chroma, p_options,
-    )
-    if error.code != 0:
-        raise _error.HeifError(
-            code=error.code,
-            subcode=error.subcode,
-            message=_libheif_cffi.ffi.string(error.message).decode(),
-        )
-    img = p_img[0]
 
     metadata = _read_metadata(handle)
     color_profile = _read_color_profile(handle)
@@ -148,7 +119,8 @@ def _read_heif_handle(handle, apply_transformations, convert_hdr_to_8bit):
         metadata=metadata,
         color_profile=color_profile,
     )
-    heif_file.data, heif_file.stride = _read_heif_image(img, height)
+    heif_file.data, heif_file.stride = _read_heif_image(
+        handle, heif_file, apply_transformations, convert_hdr_to_8bit)
     return heif_file
 
 
@@ -218,14 +190,44 @@ def _read_color_profile(handle):
     return color_profile
 
 
-def _read_heif_image(img, height):
+def _read_heif_image(handle, heif_file, apply_transformations, convert_hdr_to_8bit):
+    colorspace = _constants.heif_colorspace_RGB
+    if convert_hdr_to_8bit or heif_file.bit_depth <= 8:
+        if heif_file.has_alpha:
+            chroma = _constants.heif_chroma_interleaved_RGBA
+        else:
+            chroma = _constants.heif_chroma_interleaved_RGB
+    else:
+        if heif_file.has_alpha:
+            chroma = _constants.heif_chroma_interleaved_RRGGBBAA_BE
+        else:
+            chroma = _constants.heif_chroma_interleaved_RRGGBB_BE
+
+    p_options = _libheif_cffi.lib.heif_decoding_options_alloc()
+    p_options = _libheif_cffi.ffi.gc(
+        p_options, _libheif_cffi.lib.heif_decoding_options_free)
+    p_options.ignore_transformations = int(not apply_transformations)
+    p_options.convert_hdr_to_8bit = int(convert_hdr_to_8bit)
+
+    p_img = _libheif_cffi.ffi.new("struct heif_image **")
+    error = _libheif_cffi.lib.heif_decode_image(
+        handle, p_img, colorspace, chroma, p_options,
+    )
+    if error.code != 0:
+        raise _error.HeifError(
+            code=error.code,
+            subcode=error.subcode,
+            message=_libheif_cffi.ffi.string(error.message).decode(),
+        )
+    img = p_img[0]
+
     p_stride = _libheif_cffi.ffi.new("int *")
     p_data = _libheif_cffi.lib.heif_image_get_plane_readonly(
         img, _constants.heif_channel_interleaved, p_stride
     )
     stride = p_stride[0]
 
-    data_length = height * stride
+    data_length = heif_file.size[1] * stride
 
     # Release image as soon as no references to p_data left
     collect = functools.partial(_release_heif_image, img)

--- a/pyheif/reader.py
+++ b/pyheif/reader.py
@@ -113,7 +113,7 @@ def _read_heif_bytes(d, apply_transformations, convert_hdr_to_8bit):
 
     ctx = _libheif_cffi.lib.heif_context_alloc()
     collect = _keep_refs(_libheif_cffi.lib.heif_context_free, data=d)
-    ctx = _libheif_cffi.ffi.gc(ctx, collect)
+    ctx = _libheif_cffi.ffi.gc(ctx, collect, size=len(d))
     return _read_heif_context(ctx, d, apply_transformations, convert_hdr_to_8bit)
 
 
@@ -269,7 +269,7 @@ def _read_heif_image(handle, heif_file):
 
     # Release image as soon as no references to p_data left
     collect = functools.partial(_release_heif_image, img)
-    p_data = _libheif_cffi.ffi.gc(p_data, collect)
+    p_data = _libheif_cffi.ffi.gc(p_data, collect, size=data_length)
 
     # ffi.buffer obligatory keeps a reference to p_data
     data_buffer = _libheif_cffi.ffi.buffer(p_data, data_length)

--- a/pyheif/reader.py
+++ b/pyheif/reader.py
@@ -124,17 +124,15 @@ def _read_heif_handle(handle, apply_transformations, convert_hdr_to_8bit):
             chroma = _constants.heif_chroma_interleaved_RRGGBB_BE
 
     p_options = _libheif_cffi.lib.heif_decoding_options_alloc()
-    try:
-        p_options.ignore_transformations = int(not apply_transformations)
-        p_options.convert_hdr_to_8bit = int(convert_hdr_to_8bit)
+    p_options = _libheif_cffi.ffi.gc(
+        p_options, _libheif_cffi.lib.heif_decoding_options_free)
+    p_options.ignore_transformations = int(not apply_transformations)
+    p_options.convert_hdr_to_8bit = int(convert_hdr_to_8bit)
 
-        p_img = _libheif_cffi.ffi.new("struct heif_image **")
-        error = _libheif_cffi.lib.heif_decode_image(
-            handle, p_img, colorspace, chroma, p_options,
-        )
-    finally:
-        _libheif_cffi.lib.heif_decoding_options_free(p_options)
-
+    p_img = _libheif_cffi.ffi.new("struct heif_image **")
+    error = _libheif_cffi.lib.heif_decode_image(
+        handle, p_img, colorspace, chroma, p_options,
+    )
     if error.code != 0:
         raise _error.HeifError(
             code=error.code,

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -144,11 +144,18 @@ def test_open_and_load():
         if heif_file.color_profile:
             last_color_profile = heif_file.color_profile
 
-        heif_file.load()
+        res = heif_file.load()
+        assert heif_file is res
         assert heif_file.data is not None
         assert heif_file.stride is not None
         assert len(heif_file.data) >= heif_file.stride * heif_file.size[1]
         assert type(heif_file.data[:100]) == bytes
+
+        # Subsequent calls don't change anything
+        res = heif_file.load()
+        assert heif_file is res
+        assert heif_file.data is not None
+        assert heif_file.stride is not None
 
     # Check at least one file has it
     assert last_metadata is not None


### PR DESCRIPTION
Two important notes:

1. **This PR doesn't change existing API.** Only new function `pyheif.open()` added.

2. This PR depends on #52 and contains extra diffs which will go away as #52 will be merged.

## Rationale

Current API (`pyheif.read()`) opens image and decode it in one step. There is no way to check image properties without decoding. This makes impossible two scenarios.

1. If you only need to get image properties and don't need actual image content.
2. If you want to check image properties before decoding to be sure it will not consume too much resources.

To achieve this new method `pyheif.open()` added. Unlike `pyheif.read()`, it returns `UndecodedHeifFile` instead of `HeifFile`.

`UndecodedHeifFile` have all metadata which `HeifFile` have but don't have `data` and `stride` properties. Instead it have `.load()` method which actually decodes the image and returns `HeifFile`.

Technically speaking `UndecodedHeifFile.load()` returns the same object (self) with changed class to `HeifFile` in-place. This prevents meaningless subsequent `UndecodedHeifFile.load()` calls.

This scheme is very similar with Pillow where you can get an `ImageFile` instance with `Image.open()` function and then decode image with explicit or implicit `ImageFile.load()` call which alters self object in-place.

## cffi interface

There are some changes in C layer. As decoding is delayed until function `UndecodedHeifFile.load()` call, we need to save handle + context + source binary data  and prevent collecting. I decided to use Python native memory management. Unfortunately there is no way to just assign one object to another (like `ctx._data = d`), so I used `ffi.gc()` method to keep reference in destructor.

## Benchmarks

```python
In [7]: pyheif.open('./full.heic')
Out[7]: <UndecodedHeifFile 3024x4032 RGB with no data>

In [8]: %timeit pyheif.open('./full.heic')
591 µs ± 23.5 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

In [9]: pyheif.open('./full.heic').load()
Out[9]: <HeifFile 3024x4032 RGB with 36578304 bytes data>

In [10]: %timeit pyheif.open('./full.heic').load()
536 ms ± 2.55 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
