### PR TITLE
Cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The `pyheif.read(path_or_bytes)` function can be used to read the primary image 
 * A Python `bytes` or `bytearray` object containing HEIF content
 * A file-like object with a `.read()` method that returns bytes
 
-It returns a `HeifFile` object.
+It returns a `HeifImage` object.
 
 ```python
 import pyheif
@@ -59,7 +59,7 @@ heif_file = pyheif.read(open("IMG_7424.HEIC", "rb").read())
 
 ### Converting to a Pillow Image object
 
-If your HEIF file contains an image that you would like to manipulate, you can do so using the [Pillow](https://pillow.readthedocs.io/) Python library. You can convert a `HeifFile` to a Pillow image like so:
+If your HEIF file contains an image that you would like to manipulate, you can do so using the [Pillow](https://pillow.readthedocs.io/) Python library. You can convert a `HeifImage` to a Pillow image like so:
 
 ```python
 from PIL import Image
@@ -92,9 +92,9 @@ It returns a `HeifContainer` object.
 
 ## Objects
 
-### The HeifFile object
+### The HeifImage object
 
-The `HeifFile` has the following properties:
+The `HeifImage` has the following properties:
 
 * `mode` - the image mode, e.g. "RGB" or "RGBA"
 * `size` - the size of the image as a `(width, height)` tuple of integers
@@ -104,9 +104,9 @@ The `HeifFile` has the following properties:
 * `stride` - the number of bytes in a row of decoded file data
 * `bit_depth` - the number of bits in each component of a pixel
 
-### The UndecodedHeifFile object
+### The UndecodedHeifImage object
 
-This is a HEIF image that has not been decoded. Calling the `UndecodedHeifFile.load()` method will load the data and the object will become a `HeifFile`
+This is a HEIF image that has not been decoded. Calling the `UndecodedHeifImage.load()` method will load the data and the object will become a `HeifImage`
 
 ### The HeifContainer object
 
@@ -120,7 +120,7 @@ The `HeifContainer` has the following properties:
 The `HeifTopLevelImage` has the following properties:
 
 * `id` - the id of the image
-* `image` - the `UndecodedHeifFile` or `HeifFile` object of the image
+* `image` - the `UndecodedHeifImage` or `HeifImage` object of the image
 * `is_primary` - is this the primary image in the container
 * `depth_image` - the `HeifDepthImage` if there is one
 * `auxiliary_images` - a list of `HeifAuxiliaryImage` objects
@@ -130,14 +130,14 @@ The `HeifTopLevelImage` has the following properties:
 The `HeifDepthImage` has the following properties:
 
 * `id` - the id of the image
-* `image` - the `UndecodedHeifFile` or `HeifFile` object of the image
+* `image` - the `UndecodedHeifImage` or `HeifImage` object of the image
 
 ### The HeifAuxiliaryImage object
 
 The `HeifAuxiliaryImage` has the following properties:
 
 * `id` - the id of the image
-* `image` - the `UndecodedHeifFile` or `HeifFile` object of the image
+* `image` - the `UndecodedHeifImage` or `HeifImage` object of the image
 * `type` - a string indicating the type of auxiliary image
 
 

--- a/pyheif/error.py
+++ b/pyheif/error.py
@@ -1,4 +1,4 @@
-import _libheif_cffi
+from _libheif_cffi import ffi
 
 
 class HeifError(Exception):
@@ -27,5 +27,5 @@ def _assert_success(error):
         raise HeifError(
             code=error.code,
             subcode=error.subcode,
-            message=_libheif_cffi.ffi.string(error.message).decode(),
+            message=ffi.string(error.message).decode(),
         )

--- a/pyheif/reader.py
+++ b/pyheif/reader.py
@@ -8,7 +8,7 @@ from . import constants as _constants
 from .error import _assert_success, HeifNoImageError
 
 
-class HeifFile:
+class HeifImage:
     def __init__(
         self, *, size, has_alpha, bit_depth, metadata, color_profile, data, stride
     ):
@@ -34,7 +34,7 @@ class HeifFile:
         pass  # TODO: release self.data here?
 
 
-class UndecodedHeifFile(HeifFile):
+class UndecodedHeifImage(HeifImage):
     def __init__(
         self, heif_handle, *, apply_transformations, convert_hdr_to_8bit, **kwargs
     ):
@@ -46,13 +46,18 @@ class UndecodedHeifFile(HeifFile):
     def load(self):
         self.data, self.stride = _read_heif_image(self._heif_handle, self)
         self.close()
-        self.__class__ = HeifFile
+        self.__class__ = HeifImage
         return self
 
     def close(self):
         # Don't call super().close() here, we don't need to free bytes.
         if hasattr(self, "_heif_handle"):
             del self._heif_handle
+
+
+# This names are deprecated an will be removed in 1.0
+HeifFile = HeifImage
+UndecodedHeifFile = UndecodedHeifImage
 
 
 class HeifContainer:
@@ -90,7 +95,7 @@ def check(fp):
 
 
 def read_heif(fp, apply_transformations=True):
-    warnings.warn("read_heif is deprecated, use read instead", DeprecationWarning)
+    warnings.warn("read_heif is deprecated, use read() instead", DeprecationWarning)
     return read(fp, apply_transformations=apply_transformations)
 
 
@@ -216,7 +221,7 @@ def _read_heif_handle(handle, apply_transformations, convert_hdr_to_8bit):
     metadata = _read_metadata(handle)
     color_profile = _read_color_profile(handle)
 
-    heif_file = UndecodedHeifFile(
+    heif_file = UndecodedHeifImage(
         handle,
         size=(width, height),
         has_alpha=has_alpha,

--- a/pyheif/reader.py
+++ b/pyheif/reader.py
@@ -138,7 +138,7 @@ def _get_bytes(fp, length=None):
 def _keep_refs(destructor, **refs):
     """
     Keep refs to passed arguments until `inner` callback exist.
-    This prevents collecting parent objects until all children collcted.
+    This prevents collecting parent objects until all children collected.
     """
 
     def inner(cdata):
@@ -182,9 +182,9 @@ def _read_heif_container(ctx, apply_transformations, convert_hdr_to_8bit):
     primary_image = None
     top_level_images = []
 
-    for id in ids:
+    for handle_id in ids:
         p_handle = ffi.new("struct heif_image_handle **")
-        error = libheif.heif_context_get_image_handle(ctx, id, p_handle)
+        error = libheif.heif_context_get_image_handle(ctx, handle_id, p_handle)
         _assert_success(error)
 
         collect = _keep_refs(libheif.heif_image_handle_release, ctx=ctx)
@@ -192,7 +192,7 @@ def _read_heif_container(ctx, apply_transformations, convert_hdr_to_8bit):
 
         image = _read_heif_handle(handle, apply_transformations, convert_hdr_to_8bit)
 
-        is_primary = id == primary_image_id
+        is_primary = handle_id == primary_image_id
 
         depth_image = _read_depth_image(
             handle, apply_transformations, convert_hdr_to_8bit
@@ -202,7 +202,7 @@ def _read_heif_container(ctx, apply_transformations, convert_hdr_to_8bit):
         )
 
         top_level_image = HeifTopLevelImage(
-            id, image, is_primary, depth_image, auxiliary_images
+            handle_id, image, is_primary, depth_image, auxiliary_images
         )
 
         top_level_images.append(top_level_image)

--- a/pyheif/reader.py
+++ b/pyheif/reader.py
@@ -3,7 +3,7 @@ import functools
 import pathlib
 import warnings
 
-import _libheif_cffi
+from _libheif_cffi import ffi, lib as libheif
 from . import constants as _constants
 from . import error as _error
 
@@ -85,7 +85,7 @@ class HeifAuxiliaryImage:
 
 def check(fp):
     magic = _get_bytes(fp, 12)
-    filetype_check = _libheif_cffi.lib.heif_check_filetype(magic, len(magic))
+    filetype_check = libheif.heif_check_filetype(magic, len(magic))
     return filetype_check
 
 
@@ -145,47 +145,45 @@ def _keep_refs(destructor, **refs):
 
 def _get_heif_context(d):
     magic = d[:12]
-    filetype_check = _libheif_cffi.lib.heif_check_filetype(magic, len(magic))
+    filetype_check = libheif.heif_check_filetype(magic, len(magic))
     if filetype_check == _constants.heif_filetype_no:
         raise ValueError("Input is not a HEIF/AVIF file")
     elif filetype_check == _constants.heif_filetype_yes_unsupported:
         warnings.warn("Input is an unsupported HEIF/AVIF file type - trying anyway!")
 
-    ctx = _libheif_cffi.lib.heif_context_alloc()
-    collect = _keep_refs(_libheif_cffi.lib.heif_context_free, data=d)
-    ctx = _libheif_cffi.ffi.gc(ctx, collect, size=len(d))
+    ctx = libheif.heif_context_alloc()
+    collect = _keep_refs(libheif.heif_context_free, data=d)
+    ctx = ffi.gc(ctx, collect, size=len(d))
 
-    error = _libheif_cffi.lib.heif_context_read_from_memory_without_copy(
-        ctx, d, len(d), _libheif_cffi.ffi.NULL
-    )
+    error = libheif.heif_context_read_from_memory_without_copy(ctx, d, len(d), ffi.NULL)
     _error._assert_success(error)
     return ctx
 
 
 def _read_heif_container(ctx, apply_transformations, convert_hdr_to_8bit):
-    image_count = _libheif_cffi.lib.heif_context_get_number_of_top_level_images(ctx)
+    image_count = libheif.heif_context_get_number_of_top_level_images(ctx)
     if image_count == 0:
         raise _error.HeifNoImageError()
 
-    ids = _libheif_cffi.ffi.new("heif_item_id[]", image_count)
-    image_count = _libheif_cffi.lib.heif_context_get_list_of_top_level_image_IDs(
+    ids = ffi.new("heif_item_id[]", image_count)
+    image_count = libheif.heif_context_get_list_of_top_level_image_IDs(
         ctx, ids, image_count
     )
 
-    p_primary_image_id = _libheif_cffi.ffi.new("heif_item_id *")
-    error = _libheif_cffi.lib.heif_context_get_primary_image_ID(ctx, p_primary_image_id)
+    p_primary_image_id = ffi.new("heif_item_id *")
+    error = libheif.heif_context_get_primary_image_ID(ctx, p_primary_image_id)
     _error._assert_success(error)
     primary_image_id = p_primary_image_id[0]
     primary_image = None
     top_level_images = []
 
     for id in ids:
-        p_handle = _libheif_cffi.ffi.new("struct heif_image_handle **")
-        error = _libheif_cffi.lib.heif_context_get_image_handle(ctx, id, p_handle)
+        p_handle = ffi.new("struct heif_image_handle **")
+        error = libheif.heif_context_get_image_handle(ctx, id, p_handle)
         _error._assert_success(error)
 
-        collect = _keep_refs(_libheif_cffi.lib.heif_image_handle_release, ctx=ctx)
-        handle = _libheif_cffi.ffi.gc(p_handle[0], collect)
+        collect = _keep_refs(libheif.heif_image_handle_release, ctx=ctx)
+        handle = ffi.gc(p_handle[0], collect)
 
         image = _read_heif_handle(handle, apply_transformations, convert_hdr_to_8bit)
 
@@ -210,10 +208,10 @@ def _read_heif_container(ctx, apply_transformations, convert_hdr_to_8bit):
 
 
 def _read_heif_handle(handle, apply_transformations, convert_hdr_to_8bit):
-    width = _libheif_cffi.lib.heif_image_handle_get_width(handle)
-    height = _libheif_cffi.lib.heif_image_handle_get_height(handle)
-    has_alpha = bool(_libheif_cffi.lib.heif_image_handle_has_alpha_channel(handle))
-    bit_depth = _libheif_cffi.lib.heif_image_handle_get_luma_bits_per_pixel(handle)
+    width = libheif.heif_image_handle_get_width(handle)
+    height = libheif.heif_image_handle_get_height(handle)
+    has_alpha = bool(libheif.heif_image_handle_has_alpha_channel(handle))
+    bit_depth = libheif.heif_image_handle_get_luma_bits_per_pixel(handle)
 
     metadata = _read_metadata(handle)
     color_profile = _read_color_profile(handle)
@@ -232,23 +230,21 @@ def _read_heif_handle(handle, apply_transformations, convert_hdr_to_8bit):
 
 
 def _read_depth_image(handle, apply_transformations, convert_hdr_to_8bit):
-    has_depth_image = _libheif_cffi.lib.heif_image_handle_has_depth_image(handle)
+    has_depth_image = libheif.heif_image_handle_has_depth_image(handle)
     if has_depth_image:
-        p_depth_image_id = _libheif_cffi.ffi.new("heif_item_id *")
-        n_depth_images = _libheif_cffi.lib.heif_image_handle_get_list_of_depth_image_IDs(
+        p_depth_image_id = ffi.new("heif_item_id *")
+        n_depth_images = libheif.heif_image_handle_get_list_of_depth_image_IDs(
             handle, p_depth_image_id, 1
         )
         if n_depth_images == 1:
             depth_id = p_depth_image_id[0]
-            p_depth_handle = _libheif_cffi.ffi.new("struct heif_image_handle **")
-            error = _libheif_cffi.lib.heif_image_handle_get_depth_image_handle(
+            p_depth_handle = ffi.new("struct heif_image_handle **")
+            error = libheif.heif_image_handle_get_depth_image_handle(
                 handle, depth_id, p_depth_handle
             )
             _error._assert_success(error)
-            collect = _keep_refs(
-                _libheif_cffi.lib.heif_image_handle_release, handle=handle
-            )
-            depth_handle = _libheif_cffi.ffi.gc(p_depth_handle[0], collect)
+            collect = _keep_refs(libheif.heif_image_handle_release, handle=handle)
+            depth_handle = ffi.gc(p_depth_handle[0], collect)
             return HeifDepthImage(
                 depth_id,
                 _read_heif_handle(
@@ -259,15 +255,15 @@ def _read_depth_image(handle, apply_transformations, convert_hdr_to_8bit):
 
 
 def _read_all_auxiliary_images(handle, apply_transformations, convert_hdr_to_8bit):
-    aux_count = _libheif_cffi.lib.heif_image_handle_get_number_of_auxiliary_images(
+    aux_count = libheif.heif_image_handle_get_number_of_auxiliary_images(
         handle,
         _constants.LIBHEIF_AUX_IMAGE_FILTER_OMIT_ALPHA
         | _constants.LIBHEIF_AUX_IMAGE_FILTER_OMIT_DEPTH,
     )
     if aux_count == 0:
         return []
-    aux_ids = _libheif_cffi.ffi.new("heif_item_id[]", aux_count)
-    aux_count = _libheif_cffi.lib.heif_image_handle_get_list_of_auxiliary_image_IDs(
+    aux_ids = ffi.new("heif_item_id[]", aux_count)
+    aux_count = libheif.heif_image_handle_get_list_of_auxiliary_image_IDs(
         handle,
         _constants.LIBHEIF_AUX_IMAGE_FILTER_OMIT_ALPHA
         | _constants.LIBHEIF_AUX_IMAGE_FILTER_OMIT_DEPTH,
@@ -286,22 +282,20 @@ def _read_all_auxiliary_images(handle, apply_transformations, convert_hdr_to_8bi
 def _read_auxiliary_image(
     handle, auxiliary_image_id, apply_transformations, convert_hdr_to_8bit
 ):
-    p_aux_handle = _libheif_cffi.ffi.new("struct heif_image_handle **")
-    error = _libheif_cffi.lib.heif_image_handle_get_auxiliary_image_handle(
+    p_aux_handle = ffi.new("struct heif_image_handle **")
+    error = libheif.heif_image_handle_get_auxiliary_image_handle(
         handle, auxiliary_image_id, p_aux_handle
     )
     _error._assert_success(error)
 
-    collect = _keep_refs(_libheif_cffi.lib.heif_image_handle_release, handle=handle)
-    aux_handle = _libheif_cffi.ffi.gc(p_aux_handle[0], collect)
+    collect = _keep_refs(libheif.heif_image_handle_release, handle=handle)
+    aux_handle = ffi.gc(p_aux_handle[0], collect)
 
-    p_aux_type = _libheif_cffi.ffi.new("char **")
-    error = _libheif_cffi.lib.heif_image_handle_get_auxiliary_type(
-        aux_handle, p_aux_type
-    )
+    p_aux_type = ffi.new("char **")
+    error = libheif.heif_image_handle_get_auxiliary_type(aux_handle, p_aux_type)
     _error._assert_success(error)
-    aux_type = _libheif_cffi.ffi.string(p_aux_type[0]).decode()
-    _libheif_cffi.lib.heif_image_handle_free_auxiliary_types(aux_handle, p_aux_type)
+    aux_type = ffi.string(p_aux_type[0]).decode()
+    libheif.heif_image_handle_free_auxiliary_types(aux_handle, p_aux_type)
 
     return HeifAuxiliaryImage(
         auxiliary_image_id,
@@ -311,30 +305,26 @@ def _read_auxiliary_image(
 
 
 def _read_metadata(handle):
-    block_count = _libheif_cffi.lib.heif_image_handle_get_number_of_metadata_blocks(
-        handle, _libheif_cffi.ffi.NULL
+    block_count = libheif.heif_image_handle_get_number_of_metadata_blocks(
+        handle, ffi.NULL
     )
     if block_count == 0:
         return
 
     metadata = []
-    ids = _libheif_cffi.ffi.new("heif_item_id[]", block_count)
-    _libheif_cffi.lib.heif_image_handle_get_list_of_metadata_block_IDs(
-        handle, _libheif_cffi.ffi.NULL, ids, block_count
+    ids = ffi.new("heif_item_id[]", block_count)
+    libheif.heif_image_handle_get_list_of_metadata_block_IDs(
+        handle, ffi.NULL, ids, block_count
     )
     for i in range(len(ids)):
-        metadata_type = _libheif_cffi.lib.heif_image_handle_get_metadata_type(
-            handle, ids[i]
-        )
-        metadata_type = _libheif_cffi.ffi.string(metadata_type).decode()
-        data_length = _libheif_cffi.lib.heif_image_handle_get_metadata_size(
-            handle, ids[i]
-        )
-        p_data = _libheif_cffi.ffi.new("char[]", data_length)
-        error = _libheif_cffi.lib.heif_image_handle_get_metadata(handle, ids[i], p_data)
+        metadata_type = libheif.heif_image_handle_get_metadata_type(handle, ids[i])
+        metadata_type = ffi.string(metadata_type).decode()
+        data_length = libheif.heif_image_handle_get_metadata_size(handle, ids[i])
+        p_data = ffi.new("char[]", data_length)
+        error = libheif.heif_image_handle_get_metadata(handle, ids[i], p_data)
         _error._assert_success(error)
 
-        data_buffer = _libheif_cffi.ffi.buffer(p_data, data_length)
+        data_buffer = ffi.buffer(p_data, data_length)
         data = bytes(data_buffer)
         if metadata_type == "Exif":
             # skip TIFF header, first 4 bytes
@@ -345,37 +335,29 @@ def _read_metadata(handle):
 
 
 def _read_color_profile(handle):
-    profile_type = _libheif_cffi.lib.heif_image_handle_get_color_profile_type(handle)
+    profile_type = libheif.heif_image_handle_get_color_profile_type(handle)
     if profile_type == _constants.heif_color_profile_type_not_present:
         return
 
     color_profile = {"type": "unknown", "data": None}
     if profile_type == _constants.heif_color_profile_type_nclx:
         color_profile["type"] = "nclx"
-        data_length = _libheif_cffi.ffi.sizeof("struct heif_color_profile_nclx")
-        pp_data = _libheif_cffi.ffi.new("struct heif_color_profile_nclx * *")
-        error = _libheif_cffi.lib.heif_image_handle_get_nclx_color_profile(
-            handle, pp_data
-        )
-        p_data = _libheif_cffi.ffi.gc(
-            pp_data[0], _libheif_cffi.lib.heif_nclx_color_profile_free
-        )
+        data_length = ffi.sizeof("struct heif_color_profile_nclx")
+        pp_data = ffi.new("struct heif_color_profile_nclx * *")
+        error = libheif.heif_image_handle_get_nclx_color_profile(handle, pp_data)
+        p_data = ffi.gc(pp_data[0], libheif.heif_nclx_color_profile_free)
 
     else:
         if profile_type == _constants.heif_color_profile_type_rICC:
             color_profile["type"] = "rICC"
         elif profile_type == _constants.heif_color_profile_type_prof:
             color_profile["type"] = "prof"
-        data_length = _libheif_cffi.lib.heif_image_handle_get_raw_color_profile_size(
-            handle
-        )
-        p_data = _libheif_cffi.ffi.new("char[]", data_length)
-        error = _libheif_cffi.lib.heif_image_handle_get_raw_color_profile(
-            handle, p_data
-        )
+        data_length = libheif.heif_image_handle_get_raw_color_profile_size(handle)
+        p_data = ffi.new("char[]", data_length)
+        error = libheif.heif_image_handle_get_raw_color_profile(handle, p_data)
 
     _error._assert_success(error)
-    data_buffer = _libheif_cffi.ffi.buffer(p_data, data_length)
+    data_buffer = ffi.buffer(p_data, data_length)
     data = bytes(data_buffer)
     color_profile["data"] = data
 
@@ -395,23 +377,21 @@ def _read_heif_image(handle, heif_file):
         else:
             chroma = _constants.heif_chroma_interleaved_RRGGBB_BE
 
-    p_options = _libheif_cffi.lib.heif_decoding_options_alloc()
-    p_options = _libheif_cffi.ffi.gc(
-        p_options, _libheif_cffi.lib.heif_decoding_options_free
-    )
+    p_options = libheif.heif_decoding_options_alloc()
+    p_options = ffi.gc(p_options, libheif.heif_decoding_options_free)
     p_options.ignore_transformations = int(not heif_file.apply_transformations)
     p_options.convert_hdr_to_8bit = int(heif_file.convert_hdr_to_8bit)
 
-    p_img = _libheif_cffi.ffi.new("struct heif_image **")
-    error = _libheif_cffi.lib.heif_decode_image(
+    p_img = ffi.new("struct heif_image **")
+    error = libheif.heif_decode_image(
         handle, p_img, colorspace, chroma, p_options,
     )
     _error._assert_success(error)
 
     img = p_img[0]
 
-    p_stride = _libheif_cffi.ffi.new("int *")
-    p_data = _libheif_cffi.lib.heif_image_get_plane_readonly(
+    p_stride = ffi.new("int *")
+    p_data = libheif.heif_image_get_plane_readonly(
         img, _constants.heif_channel_interleaved, p_stride
     )
     stride = p_stride[0]
@@ -420,13 +400,13 @@ def _read_heif_image(handle, heif_file):
 
     # Release image as soon as no references to p_data left
     collect = functools.partial(_release_heif_image, img)
-    p_data = _libheif_cffi.ffi.gc(p_data, collect, size=data_length)
+    p_data = ffi.gc(p_data, collect, size=data_length)
 
     # ffi.buffer obligatory keeps a reference to p_data
-    data_buffer = _libheif_cffi.ffi.buffer(p_data, data_length)
+    data_buffer = ffi.buffer(p_data, data_length)
 
     return data_buffer, stride
 
 
 def _release_heif_image(img, p_data=None):
-    _libheif_cffi.lib.heif_image_release(img)
+    libheif.heif_image_release(img)


### PR DESCRIPTION
Changes:

* Add init for tests to make it package (pytest works better when pyheif is installed globally and tested locally)
* Shorter lib names. Improves readability a bit
* Import names from `.error` because `_error._assert_success` looks ugly
* Rename HeifFile to HeifImage. It should be done before 1.0 to reduce confusion. It probably worth to rename `HeifTopLevelImage`, `HeifDepthImage` and `HeifAuxiliaryImage` to `HeifTopLevelItem`, `HeifDepthItem` and `HeifAuxiliaryItem`.
* Avoid using builtin name id