### PR TITLE
Modernize Docker build pipeline and CI matrix for libheif/Python compatibility testing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
-.*
+.git*
 build
 *.so
 Dockerfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,23 +10,24 @@ permissions:
   actions: write
 
 jobs:
-  libheif-deps-cache:
+  libheif-cache:
     name: Warm libheif dependencies cache
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
 
       - name: Warm libheif deps cache
-        run: |
-          docker build --target=libheif-deps --output type=cacheonly . \
-            --cache-from type=gha,scope=libheif-deps \
-            --cache-to type=gha,scope=libheif-deps
+        uses: docker/build-push-action@v6
+        with:
+          target: libheif
+          cache-from: type=gha,scope=libheif
+          cache-to: type=gha,mode=max,scope=libheif
 
   test-default-libheif-all-python:
     name: Test default libheif on Python ${{ matrix.python_version }}
     runs-on: ubuntu-latest
-    needs: libheif-deps-cache
+    needs: libheif-cache
     strategy:
       fail-fast: false
       matrix:
@@ -40,18 +41,19 @@ jobs:
           - cp314-cp314
           - pp311-pypy311_pp73
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
 
       - name: Build and test (default libheif + python matrix)
-        run: |
-          make test PYTHON_VERSION='${{ matrix.python_version }}' \
-            DOCKER_BUILD_EXTRA_ARGS='--cache-from type=gha,scope=libheif-deps'
+        uses: docker/build-push-action@v6
+        with:
+          cache-from: type=gha,scope=libheif
+          build-args: PYTHON_VERSION=${{ matrix.python_version }}
 
   test-default-python-all-libheif:
     name: Test libheif ${{ matrix.libheif_version }} with default Python
     runs-on: ubuntu-latest
-    needs: libheif-deps-cache
+    needs: libheif-cache
     strategy:
       fail-fast: false
       matrix:
@@ -62,10 +64,11 @@ jobs:
           - 1.20.2
           - 1.21.2
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
 
       - name: Build and test (python default + libheif matrix)
-        run: |
-          make test LIBHEIF_VERSION='${{ matrix.libheif_version }}' \
-            DOCKER_BUILD_EXTRA_ARGS='--cache-from type=gha,scope=libheif-deps'
+        uses: docker/build-push-action@v6
+        with:
+          cache-from: type=gha,scope=libheif
+          build-args: LIBHEIF_VERSION=${{ matrix.libheif_version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: read
-  actions: write
 
 jobs:
   libheif-cache:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,72 @@
+name: Test
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  libheif-deps-cache:
+    name: Warm libheif dependencies cache
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Warm libheif deps cache
+        run: |
+          docker build --platform=linux/$(ARCH) --target=libheif-deps . \
+            --cache-from type=gha,scope=libheif-deps \
+            --cache-to type=gha,scope=libheif-deps \
+            --output type=cacheonly
+
+  test-default-libheif-all-python:
+    name: Test default libheif on Python ${{ matrix.python_version }}
+    runs-on: ubuntu-latest
+    needs: libheif-deps-cache
+    strategy:
+      fail-fast: false
+      matrix:
+        python_version:
+          - cp38-cp38
+          - cp39-cp39
+          - cp310-cp310
+          - cp311-cp311
+          - cp312-cp312
+          - cp313-cp313
+          - cp314-cp314
+          - pp311-pypy311_pp73
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build and test (default libheif + python matrix)
+        run: |
+          make test PYTHON_VERSION='${{ matrix.python_version }}' \
+            DOCKER_BUILD_EXTRA_ARGS='--cache-from type=gha,scope=libheif-deps'
+
+  test-default-python-all-libheif:
+    name: Test libheif ${{ matrix.libheif_version }} with default Python
+    runs-on: ubuntu-latest
+    needs: libheif-deps-cache
+    strategy:
+      fail-fast: false
+      matrix:
+        libheif_version:
+          - 1.16.2
+          - 1.18.2
+          - 1.19.8
+          - 1.20.2
+          - 1.21.2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build and test (python default + libheif matrix)
+        run: |
+          make test LIBHEIF_VERSION='${{ matrix.libheif_version }}' \
+            DOCKER_BUILD_EXTRA_ARGS='--cache-from type=gha,scope=libheif-deps'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,10 +19,9 @@ jobs:
 
       - name: Warm libheif deps cache
         run: |
-          docker build --platform=linux/$(ARCH) --target=libheif-deps . \
+          docker build --target=libheif-deps --output type=cacheonly . \
             --cache-from type=gha,scope=libheif-deps \
-            --cache-to type=gha,scope=libheif-deps \
-            --output type=cacheonly
+            --cache-to type=gha,scope=libheif-deps
 
   test-default-libheif-all-python:
     name: Test default libheif on Python ${{ matrix.python_version }}

--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,4 @@ venv.bak/
 
 #scrath
 scratch/
+.docker_build-*

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ RUN dnf install -y nasm
 RUN pipx install --force "cmake<4"
 
 
-# -------------------------------- base ------------------------------------------------
-FROM base AS build-deps
+# -------------------------------- libheif-deps ----------------------------------------
+FROM base AS libheif-deps
 
 ENV X265_VERSION=4.1
 RUN set -ex \
@@ -43,9 +43,9 @@ RUN set -ex \
 
 
 # -------------------------------- libheif ---------------------------------------------
-FROM build-deps AS libheif
+FROM libheif-deps AS libheif
 
-ARG LIBHEIF_VERSION=1.18.2
+ARG LIBHEIF_VERSION=1.21.2
 RUN set -ex \
     && LIBHEIF_VERSION="$LIBHEIF_VERSION" \
     && curl -fLO https://github.com/strukturag/libheif/releases/download/v${LIBHEIF_VERSION}/libheif-${LIBHEIF_VERSION}.tar.gz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,14 @@
-ARG PLAT=manylinux2014_x86_64
+# -------------------------------- base ------------------------------------------------
+FROM quay.io/pypa/manylinux_2_28:2026.02.06-1 AS base
 
-FROM quay.io/pypa/$PLAT:2024.08.12-1 AS base
 
-
-###############
-# Build tools #
-###############
-
+# -------------------------------- build-tools -----------------------------------------
 FROM base AS build-tools
 
 WORKDIR /build
 
-# pkg-config
+ENV PKG_CONFIG_VERSION=0.29.2
 RUN set -ex \
-    && PKG_CONFIG_VERSION="0.29.2" \
     && curl -fLO https://pkg-config.freedesktop.org/releases/pkg-config-${PKG_CONFIG_VERSION}.tar.gz \
     && tar xvf pkg-config-${PKG_CONFIG_VERSION}.tar.gz \
     && cd pkg-config-${PKG_CONFIG_VERSION} \
@@ -22,9 +17,8 @@ RUN set -ex \
     && pkg-config --version \
     && rm -rf /build
 
-# nasm
+ENV NASM_VERSION=2.15.02
 RUN set -ex \
-    && NASM_VERSION="2.15.02" \
     && curl -fLO https://www.nasm.us/pub/nasm/releasebuilds/${NASM_VERSION}/nasm-${NASM_VERSION}.tar.gz \
     && tar xvf nasm-${NASM_VERSION}.tar.gz \
     && cd nasm-${NASM_VERSION} \
@@ -34,15 +28,11 @@ RUN set -ex \
     && rm -rf /build
 
 
-################
-# Dependencies #
-################
-
+# -------------------------------- build-deps -----------------------------------------
 FROM build-tools AS build-deps
 
-# x265
+ENV X265_VERSION=3.6
 RUN set -ex \
-    && X265_VERSION="3.6" \
     && curl -fLO https://bitbucket.org/multicoreware/x265_git/downloads/x265_${X265_VERSION}.tar.gz \
     && tar xvf x265_${X265_VERSION}.tar.gz \
     && cd x265_${X265_VERSION} \
@@ -50,20 +40,19 @@ RUN set -ex \
     && make -j $(nproc) && make install && ldconfig \
     && rm -rf /build
 
-# libde265
+ENV LIBDE265_VERSION=1.0.15
 RUN set -ex \
-    && LIBDE265_VERSION="1.0.15" \
     && curl -fLO https://github.com/strukturag/libde265/releases/download/v${LIBDE265_VERSION}/libde265-${LIBDE265_VERSION}.tar.gz \
     && tar xvf libde265-${LIBDE265_VERSION}.tar.gz \
     && cd libde265-${LIBDE265_VERSION} \
     && ./autogen.sh \
-    && CXXFLAGS="-g1 -O2" ./configure --prefix /usr --disable-encoder --disable-dec265 --disable-sherlock265 --disable-dependency-tracking \
+    && CXXFLAGS="-g1 -O2" ./configure --prefix /usr --disable-encoder --disable-dec265 \
+        --disable-sherlock265 --disable-dependency-tracking \
     && make -j $(nproc) && make install && ldconfig \
     && rm -rf /build
 
-# libaom
+ENV LIBAOM_VERSION=v3.8.3
 RUN set -ex \
-    && LIBAOM_VERSION="v3.8.3" \
     && mkdir -v aom && mkdir -v aom_build && cd aom \
     && curl -fLO "https://aomedia.googlesource.com/aom/+archive/${LIBAOM_VERSION}.tar.gz" \
     && tar xvf ${LIBAOM_VERSION}.tar.gz \
@@ -73,14 +62,11 @@ RUN set -ex \
     && make -j $(nproc) && make install && ldconfig \
     && rm -rf /build
 
-##################
-# libheif 1.18.2 #
-##################
 
+# -------------------------------- libheif ---------------------------------------------
 FROM build-deps AS libheif
-ARG LIBHEIF_VERSION=1.18.2
-ARG PLAT
 
+ARG LIBHEIF_VERSION=1.18.2
 RUN set -ex \
     && LIBHEIF_VERSION="$LIBHEIF_VERSION" \
     && curl -fLO https://github.com/strukturag/libheif/releases/download/v${LIBHEIF_VERSION}/libheif-${LIBHEIF_VERSION}.tar.gz \
@@ -95,57 +81,42 @@ COPY ./ /pyheif
 RUN set -ex \
     && PNV="/opt/python/cp310-cp310/bin" \
     && $PNV/pip wheel /pyheif \
-    && auditwheel repair pyheif*.whl --plat $PLAT -w /wheelhouse \
+    && auditwheel repair pyheif*.whl -w /wheelhouse \
     && $PNV/pip install --only-binary pillow==10.4.0 -r /pyheif/requirements-test.txt \
     && $PNV/pip install /wheelhouse/*-cp310-*.whl \
     && cd /pyheif && $PNV/pytest
 
-##########################
-# Build manylinux wheels #
-##########################
 
+# -------------------------------- all-pythons-repaired --------------------------------
 FROM libheif AS all-pythons-repaired
-ARG PLAT
 
 COPY ./ /pyheif
 
-RUN /opt/python/cp37-cp37m/bin/pip wheel /pyheif
 RUN /opt/python/cp38-cp38/bin/pip wheel /pyheif
 RUN /opt/python/cp39-cp39/bin/pip wheel /pyheif
 RUN /opt/python/cp310-cp310/bin/pip wheel /pyheif
 RUN /opt/python/cp311-cp311/bin/pip wheel /pyheif
 RUN /opt/python/cp312-cp312/bin/pip wheel /pyheif
-RUN /opt/python/pp39-pypy39_pp73/bin/pip wheel /pyheif
-RUN /opt/python/pp310-pypy310_pp73/bin/pip wheel /pyheif
-RUN auditwheel repair pyheif*.whl --plat $PLAT -w /wheelhouse
+RUN /opt/python/pp311-pypy311_pp73/bin/pip wheel /pyheif
+RUN auditwheel repair pyheif*.whl -w /wheelhouse
 
 
-###############
-# Test wheels #
-###############
-
+# -------------------------------- tested ----------------------------------------------
 FROM base AS tested
 
 COPY ./requirements-test.txt /tmp/requirements-test.txt
 
-RUN /opt/python/cp37-cp37m/bin/pip install --only-binary pillow==10.4.0 -r /tmp/requirements-test.txt
 RUN /opt/python/cp38-cp38/bin/pip install --only-binary pillow==10.4.0 -r /tmp/requirements-test.txt
 RUN /opt/python/cp39-cp39/bin/pip install --only-binary pillow==10.4.0 -r /tmp/requirements-test.txt
 RUN /opt/python/cp310-cp310/bin/pip install --only-binary pillow==10.4.0 -r /tmp/requirements-test.txt
 RUN /opt/python/cp311-cp311/bin/pip install --only-binary pillow==10.4.0 -r /tmp/requirements-test.txt
 RUN /opt/python/cp312-cp312/bin/pip install --only-binary pillow==10.4.0 -r /tmp/requirements-test.txt
-RUN /opt/python/pp39-pypy39_pp73/bin/pip install --only-binary pillow==10.4.0 -r /tmp/requirements-test.txt
-RUN /opt/python/pp310-pypy310_pp73/bin/pip install --only-binary pillow==10.4.0 -r /tmp/requirements-test.txt
+RUN /opt/python/pp311-pypy311_pp73/bin/pip install --only-binary pillow==10.4.0 -r /tmp/requirements-test.txt
 
 COPY --from=all-pythons-repaired /wheelhouse /wheelhouse
 COPY ./ /pyheif
 WORKDIR /pyheif
 
-# python 3.7
-RUN set -ex \
-    && PNV="/opt/python/cp37-cp37m/bin" \
-    && $PNV/pip install /wheelhouse/*-cp37-*.whl \
-    && $PNV/pytest
 # python 3.8
 RUN set -ex \
     && PNV="/opt/python/cp38-cp38/bin" \
@@ -165,33 +136,24 @@ RUN set -ex \
 RUN set -ex \
     && PNV="/opt/python/cp311-cp311/bin" \
     && $PNV/pip install /wheelhouse/*-cp311-*.whl \
-    && $PNV/pytest    
+    && $PNV/pytest
 # python 3.12
 RUN set -ex \
     && PNV="/opt/python/cp312-cp312/bin" \
     && $PNV/pip install /wheelhouse/*-cp312-*.whl \
-    && $PNV/pytest    
-# pypy 3.9
-RUN set -ex \
-    && PNV="/opt/python/pp39-pypy39_pp73/bin" \
-    && $PNV/pip install /wheelhouse/*-pp39-*.whl \
     && $PNV/pytest
-# pypy 3.10
+# python 3.13
 RUN set -ex \
-    && PNV="/opt/python/pp310-pypy310_pp73/bin" \
-    && $PNV/pip install /wheelhouse/*-pp310-*.whl \
+    && PNV="/opt/python/cp313-cp313/bin" \
+    && $PNV/pip install /wheelhouse/*-cp313-*.whl \
     && $PNV/pytest
-
-
-#################
-# Upload wheels #
-#################
-
-FROM tested AS uploaded
-
-ARG PYPI_USERNAME
-ARG PYPI_PASSWORD
+# python 3.14
 RUN set -ex \
-    && cd "/opt/python/cp38-cp38/bin/" \
-    && ./pip install twine \
-    && ./twine upload /wheelhouse/*manylinux2014*.whl -u ${PYPI_USERNAME} -p ${PYPI_PASSWORD} \
+    && PNV="/opt/python/cp314-cp314/bin" \
+    && $PNV/pip install /wheelhouse/*-cp314-*.whl \
+    && $PNV/pytest
+# pypy 3.11
+RUN set -ex \
+    && PNV="/opt/python/pp311-pypy311_pp73/bin" \
+    && $PNV/pip install /wheelhouse/*-pp311-*.whl \
+    && $PNV/pytest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
+ARG LIBHEIF_VERSION=1.21.2
+ARG PYTHON_VERSION=cp312-cp312
+
 # -------------------------------- base ------------------------------------------------
 FROM quay.io/pypa/manylinux_2_28:2026.02.06-1 AS base
 
@@ -44,8 +47,8 @@ RUN set -ex \
 
 # -------------------------------- libheif ---------------------------------------------
 FROM libheif-deps AS libheif
+ARG LIBHEIF_VERSION
 
-ARG LIBHEIF_VERSION=1.21.2
 RUN set -ex \
     && LIBHEIF_VERSION="$LIBHEIF_VERSION" \
     && curl -fLO https://github.com/strukturag/libheif/releases/download/v${LIBHEIF_VERSION}/libheif-${LIBHEIF_VERSION}.tar.gz \
@@ -55,88 +58,31 @@ RUN set -ex \
     && make -j $(nproc) && make install && ldconfig \
     && rm -rf /build
 
+
+# -------------------------------- wheel -----------------------------------------------
+FROM libheif AS wheel
+ARG PYTHON_VERSION
+
 COPY ./ /pyheif
 
 RUN set -ex \
-    && PNV="/opt/python/cp310-cp310/bin" \
-    && $PNV/pip wheel /pyheif \
-    && auditwheel repair pyheif*.whl -w /wheelhouse \
-    && $PNV/pip install --only-binary :all: -r /pyheif/requirements-test.txt \
-    && $PNV/pip install /wheelhouse/*-cp310-*.whl \
-    && cd /pyheif && $PNV/pytest
-
-
-# -------------------------------- all-pythons-repaired --------------------------------
-FROM libheif AS all-pythons-repaired
-
-COPY ./ /pyheif
-
-RUN /opt/python/cp38-cp38/bin/pip wheel /pyheif
-RUN /opt/python/cp39-cp39/bin/pip wheel /pyheif
-RUN /opt/python/cp310-cp310/bin/pip wheel /pyheif
-RUN /opt/python/cp311-cp311/bin/pip wheel /pyheif
-RUN /opt/python/cp312-cp312/bin/pip wheel /pyheif
-RUN /opt/python/cp313-cp313/bin/pip wheel /pyheif
-RUN /opt/python/cp314-cp314/bin/pip wheel /pyheif
-RUN /opt/python/pp311-pypy311_pp73/bin/pip wheel /pyheif
-RUN auditwheel repair pyheif*.whl -w /wheelhouse
+    && /opt/python/${PYTHON_VERSION}/bin/pip wheel /pyheif \
+    && auditwheel repair pyheif*.whl -w /wheels
 
 
 # -------------------------------- tested ----------------------------------------------
 FROM base AS tested
+ARG PYTHON_VERSION
 
 COPY ./requirements-test.txt /tmp/requirements-test.txt
 
-RUN /opt/python/cp38-cp38/bin/pip install --only-binary :all: -r /tmp/requirements-test.txt
-RUN /opt/python/cp39-cp39/bin/pip install --only-binary :all: -r /tmp/requirements-test.txt
-RUN /opt/python/cp310-cp310/bin/pip install --only-binary :all: -r /tmp/requirements-test.txt
-RUN /opt/python/cp311-cp311/bin/pip install --only-binary :all: -r /tmp/requirements-test.txt
-RUN /opt/python/cp312-cp312/bin/pip install --only-binary :all: -r /tmp/requirements-test.txt
-RUN /opt/python/cp313-cp313/bin/pip install --only-binary :all: -r /tmp/requirements-test.txt
-RUN /opt/python/cp314-cp314/bin/pip install --only-binary :all: -r /tmp/requirements-test.txt
-RUN /opt/python/pp311-pypy311_pp73/bin/pip install --only-binary :all: -r /tmp/requirements-test.txt
+RUN /opt/python/${PYTHON_VERSION}/bin/pip install --only-binary :all: -r /tmp/requirements-test.txt
 
-COPY --from=all-pythons-repaired /wheelhouse /wheelhouse
+COPY --from=wheel /wheels /wheels
 COPY ./ /pyheif
 WORKDIR /pyheif
 
-# python 3.8
 RUN set -ex \
-    && PNV="/opt/python/cp38-cp38/bin" \
-    && $PNV/pip install /wheelhouse/*-cp38-*.whl \
-    && $PNV/pytest
-# python 3.9
-RUN set -ex \
-    && PNV="/opt/python/cp39-cp39/bin" \
-    && $PNV/pip install /wheelhouse/*-cp39-*.whl \
-    && $PNV/pytest
-# python 3.10
-RUN set -ex \
-    && PNV="/opt/python/cp310-cp310/bin" \
-    && $PNV/pip install /wheelhouse/*-cp310-*.whl \
-    && $PNV/pytest
-# python 3.11
-RUN set -ex \
-    && PNV="/opt/python/cp311-cp311/bin" \
-    && $PNV/pip install /wheelhouse/*-cp311-*.whl \
-    && $PNV/pytest
-# python 3.12
-RUN set -ex \
-    && PNV="/opt/python/cp312-cp312/bin" \
-    && $PNV/pip install /wheelhouse/*-cp312-*.whl \
-    && $PNV/pytest
-# python 3.13
-RUN set -ex \
-    && PNV="/opt/python/cp313-cp313/bin" \
-    && $PNV/pip install /wheelhouse/*-cp313-*.whl \
-    && $PNV/pytest
-# python 3.14
-RUN set -ex \
-    && PNV="/opt/python/cp314-cp314/bin" \
-    && $PNV/pip install /wheelhouse/*-cp314-*.whl \
-    && $PNV/pytest
-# pypy 3.11
-RUN set -ex \
-    && PNV="/opt/python/pp311-pypy311_pp73/bin" \
-    && $PNV/pip install /wheelhouse/*-pp311-*.whl \
+    && PNV="/opt/python/${PYTHON_VERSION}/bin" \
+    && $PNV/pip install /wheels/pyheif-*.whl \
     && $PNV/pytest

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,9 @@ FROM quay.io/pypa/manylinux_2_28:2026.02.06-1 AS base
 
 WORKDIR /build
 
-RUN dnf install -y nasm
+RUN dnf install -y nasm \
+    && dnf clean all \
+    && rm -rf /var/cache/dnf
 RUN pipx install --force "cmake<4"
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,37 +1,16 @@
 # -------------------------------- base ------------------------------------------------
 FROM quay.io/pypa/manylinux_2_28:2026.02.06-1 AS base
 
-
-# -------------------------------- build-tools -----------------------------------------
-FROM base AS build-tools
-
 WORKDIR /build
 
-ENV PKG_CONFIG_VERSION=0.29.2
-RUN set -ex \
-    && curl -fLO https://pkg-config.freedesktop.org/releases/pkg-config-${PKG_CONFIG_VERSION}.tar.gz \
-    && tar xvf pkg-config-${PKG_CONFIG_VERSION}.tar.gz \
-    && cd pkg-config-${PKG_CONFIG_VERSION} \
-    && ./configure \
-    && make -j $(nproc) && make install \
-    && pkg-config --version \
-    && rm -rf /build
-
-ENV NASM_VERSION=2.15.02
-RUN set -ex \
-    && curl -fLO https://www.nasm.us/pub/nasm/releasebuilds/${NASM_VERSION}/nasm-${NASM_VERSION}.tar.gz \
-    && tar xvf nasm-${NASM_VERSION}.tar.gz \
-    && cd nasm-${NASM_VERSION} \
-    && ./configure \
-    && make -j $(nproc) && make install \
-    && nasm --version \
-    && rm -rf /build
+RUN dnf install -y nasm
+RUN pipx install --force "cmake<4"
 
 
-# -------------------------------- build-deps -----------------------------------------
-FROM build-tools AS build-deps
+# -------------------------------- base ------------------------------------------------
+FROM base AS build-deps
 
-ENV X265_VERSION=3.6
+ENV X265_VERSION=4.1
 RUN set -ex \
     && curl -fLO https://bitbucket.org/multicoreware/x265_git/downloads/x265_${X265_VERSION}.tar.gz \
     && tar xvf x265_${X265_VERSION}.tar.gz \
@@ -40,7 +19,7 @@ RUN set -ex \
     && make -j $(nproc) && make install && ldconfig \
     && rm -rf /build
 
-ENV LIBDE265_VERSION=1.0.15
+ENV LIBDE265_VERSION=1.0.16
 RUN set -ex \
     && curl -fLO https://github.com/strukturag/libde265/releases/download/v${LIBDE265_VERSION}/libde265-${LIBDE265_VERSION}.tar.gz \
     && tar xvf libde265-${LIBDE265_VERSION}.tar.gz \
@@ -51,7 +30,7 @@ RUN set -ex \
     && make -j $(nproc) && make install && ldconfig \
     && rm -rf /build
 
-ENV LIBAOM_VERSION=v3.8.3
+ENV LIBAOM_VERSION=v3.13.1
 RUN set -ex \
     && mkdir -v aom && mkdir -v aom_build && cd aom \
     && curl -fLO "https://aomedia.googlesource.com/aom/+archive/${LIBAOM_VERSION}.tar.gz" \
@@ -82,7 +61,7 @@ RUN set -ex \
     && PNV="/opt/python/cp310-cp310/bin" \
     && $PNV/pip wheel /pyheif \
     && auditwheel repair pyheif*.whl -w /wheelhouse \
-    && $PNV/pip install --only-binary pillow==10.4.0 -r /pyheif/requirements-test.txt \
+    && $PNV/pip install --only-binary :all: -r /pyheif/requirements-test.txt \
     && $PNV/pip install /wheelhouse/*-cp310-*.whl \
     && cd /pyheif && $PNV/pytest
 
@@ -97,6 +76,8 @@ RUN /opt/python/cp39-cp39/bin/pip wheel /pyheif
 RUN /opt/python/cp310-cp310/bin/pip wheel /pyheif
 RUN /opt/python/cp311-cp311/bin/pip wheel /pyheif
 RUN /opt/python/cp312-cp312/bin/pip wheel /pyheif
+RUN /opt/python/cp313-cp313/bin/pip wheel /pyheif
+RUN /opt/python/cp314-cp314/bin/pip wheel /pyheif
 RUN /opt/python/pp311-pypy311_pp73/bin/pip wheel /pyheif
 RUN auditwheel repair pyheif*.whl -w /wheelhouse
 
@@ -106,12 +87,14 @@ FROM base AS tested
 
 COPY ./requirements-test.txt /tmp/requirements-test.txt
 
-RUN /opt/python/cp38-cp38/bin/pip install --only-binary pillow==10.4.0 -r /tmp/requirements-test.txt
-RUN /opt/python/cp39-cp39/bin/pip install --only-binary pillow==10.4.0 -r /tmp/requirements-test.txt
-RUN /opt/python/cp310-cp310/bin/pip install --only-binary pillow==10.4.0 -r /tmp/requirements-test.txt
-RUN /opt/python/cp311-cp311/bin/pip install --only-binary pillow==10.4.0 -r /tmp/requirements-test.txt
-RUN /opt/python/cp312-cp312/bin/pip install --only-binary pillow==10.4.0 -r /tmp/requirements-test.txt
-RUN /opt/python/pp311-pypy311_pp73/bin/pip install --only-binary pillow==10.4.0 -r /tmp/requirements-test.txt
+RUN /opt/python/cp38-cp38/bin/pip install --only-binary :all: -r /tmp/requirements-test.txt
+RUN /opt/python/cp39-cp39/bin/pip install --only-binary :all: -r /tmp/requirements-test.txt
+RUN /opt/python/cp310-cp310/bin/pip install --only-binary :all: -r /tmp/requirements-test.txt
+RUN /opt/python/cp311-cp311/bin/pip install --only-binary :all: -r /tmp/requirements-test.txt
+RUN /opt/python/cp312-cp312/bin/pip install --only-binary :all: -r /tmp/requirements-test.txt
+RUN /opt/python/cp313-cp313/bin/pip install --only-binary :all: -r /tmp/requirements-test.txt
+RUN /opt/python/cp314-cp314/bin/pip install --only-binary :all: -r /tmp/requirements-test.txt
+RUN /opt/python/pp311-pypy311_pp73/bin/pip install --only-binary :all: -r /tmp/requirements-test.txt
 
 COPY --from=all-pythons-repaired /wheelhouse /wheelhouse
 COPY ./ /pyheif

--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,12 @@ ARCH ?= amd64
 LIBHEIF_VERSION ?= 1.21.2
 PYTHON_VERSION ?= cp312-cp312
 DOCKER_IID_FILE = .docker_build-$(ARCH)-$(LIBHEIF_VERSION)-$(PYTHON_VERSION)
+DOCKER_BUILD_EXTRA_ARGS ?=
 
 
 .PHONY: test
 test:
-	docker build --platform=linux/$(ARCH) --iidfile $(DOCKER_IID_FILE) . \
+	docker build --platform=linux/$(ARCH) --iidfile $(DOCKER_IID_FILE) $(DOCKER_BUILD_EXTRA_ARGS) . \
 		--build-arg=LIBHEIF_VERSION=$(LIBHEIF_VERSION) --build-arg=PYTHON_VERSION=$(PYTHON_VERSION)
 
 

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,15 @@
 .PHONY: check_libheif_versions
 
-PLAT ?= manylinux2014_x86_64
+ARCH ?= amd64
 
 check_libheif_versions:
-	docker build --target=libheif --build-arg=PLAT=${PLAT} --build-arg=LIBHEIF_VERSION=1.16.2 .
-	docker build --target=libheif --build-arg=PLAT=${PLAT} --build-arg=LIBHEIF_VERSION=1.17.0 .
-	docker build --target=libheif --build-arg=PLAT=${PLAT} --build-arg=LIBHEIF_VERSION=1.17.5 .
-	docker build --target=libheif --build-arg=PLAT=${PLAT} --build-arg=LIBHEIF_VERSION=1.17.6 .
-	docker build --target=libheif --build-arg=PLAT=${PLAT} --build-arg=LIBHEIF_VERSION=1.18.0 .
-	docker build --target=libheif --build-arg=PLAT=${PLAT} --build-arg=LIBHEIF_VERSION=1.18.1 .
-	docker build --target=libheif --build-arg=PLAT=${PLAT} --build-arg=LIBHEIF_VERSION=1.18.2 .
+	docker build --target=libheif --platform=linux/$(ARCH) --build-arg=LIBHEIF_VERSION=1.16.2 .
+	docker build --target=libheif --platform=linux/$(ARCH) --build-arg=LIBHEIF_VERSION=1.17.0 .
+	docker build --target=libheif --platform=linux/$(ARCH) --build-arg=LIBHEIF_VERSION=1.17.5 .
+	docker build --target=libheif --platform=linux/$(ARCH) --build-arg=LIBHEIF_VERSION=1.17.6 .
+	docker build --target=libheif --platform=linux/$(ARCH) --build-arg=LIBHEIF_VERSION=1.18.0 .
+	docker build --target=libheif --platform=linux/$(ARCH) --build-arg=LIBHEIF_VERSION=1.18.1 .
+	docker build --target=libheif --platform=linux/$(ARCH) --build-arg=LIBHEIF_VERSION=1.18.2 .
 
 test:
-	docker build --target=tested --build-arg=PLAT=${PLAT} .
+	docker build --target=tested --platform=linux/$(ARCH) .

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,53 @@
 .PHONY: check_libheif_versions
 
 ARCH ?= amd64
+LIBHEIF_VERSION ?= 1.21.2
+PYTHON_VERSION ?= cp312-cp312
+DOCKER_IID_FILE = .docker_build-$(ARCH)-$(LIBHEIF_VERSION)-$(PYTHON_VERSION)
 
-check_libheif_versions:
-	docker build --target=libheif --platform=linux/$(ARCH) --build-arg=LIBHEIF_VERSION=1.16.2 .
-	docker build --target=libheif --platform=linux/$(ARCH) --build-arg=LIBHEIF_VERSION=1.18.2 .
-	docker build --target=libheif --platform=linux/$(ARCH) --build-arg=LIBHEIF_VERSION=1.19.8 .
-	docker build --target=libheif --platform=linux/$(ARCH) --build-arg=LIBHEIF_VERSION=1.20.2 .
-	docker build --target=libheif --platform=linux/$(ARCH) --build-arg=LIBHEIF_VERSION=1.21.2 .
 
+.PHONY: test
 test:
-	docker build --target=tested --platform=linux/$(ARCH) .
+	docker build --platform=linux/$(ARCH) --iidfile $(DOCKER_IID_FILE) . \
+		--build-arg=LIBHEIF_VERSION=$(LIBHEIF_VERSION) --build-arg=PYTHON_VERSION=$(PYTHON_VERSION)
+
+
+.PHONY: copy
+copy: test
+	CID=$$(docker create --platform linux/$(ARCH) $$(cat $(DOCKER_IID_FILE))) \
+	&& docker cp $${CID}:/wheels ./ \
+	&& docker rm $${CID}
+	rm $(DOCKER_IID_FILE)
+
+
+.PHONY: test_libheif_versions
+test_libheif_versions:
+	$(MAKE) test LIBHEIF_VERSION=1.16.2
+	$(MAKE) test LIBHEIF_VERSION=1.18.2
+	$(MAKE) test LIBHEIF_VERSION=1.19.8
+	$(MAKE) test LIBHEIF_VERSION=1.20.2
+	$(MAKE) test LIBHEIF_VERSION=1.21.2
+
+
+.PHONY: test_python_versions
+test_python_versions:
+	$(MAKE) test PYTHON_VERSION=cp38-cp38
+	$(MAKE) test PYTHON_VERSION=cp39-cp39
+	$(MAKE) test PYTHON_VERSION=cp310-cp310
+	$(MAKE) test PYTHON_VERSION=cp311-cp311
+	$(MAKE) test PYTHON_VERSION=cp312-cp312
+	$(MAKE) test PYTHON_VERSION=cp313-cp313
+	$(MAKE) test PYTHON_VERSION=cp314-cp314
+	$(MAKE) test PYTHON_VERSION=pp311-pypy311_pp73
+
+
+.PHONY: copy_python_versions
+copy_python_versions:
+	$(MAKE) copy PYTHON_VERSION=cp38-cp38
+	$(MAKE) copy PYTHON_VERSION=cp39-cp39
+	$(MAKE) copy PYTHON_VERSION=cp310-cp310
+	$(MAKE) copy PYTHON_VERSION=cp311-cp311
+	$(MAKE) copy PYTHON_VERSION=cp312-cp312
+	$(MAKE) copy PYTHON_VERSION=cp313-cp313
+	$(MAKE) copy PYTHON_VERSION=cp314-cp314
+	$(MAKE) copy PYTHON_VERSION=pp311-pypy311_pp73

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,10 @@ ARCH ?= amd64
 
 check_libheif_versions:
 	docker build --target=libheif --platform=linux/$(ARCH) --build-arg=LIBHEIF_VERSION=1.16.2 .
-	docker build --target=libheif --platform=linux/$(ARCH) --build-arg=LIBHEIF_VERSION=1.17.0 .
-	docker build --target=libheif --platform=linux/$(ARCH) --build-arg=LIBHEIF_VERSION=1.17.5 .
-	docker build --target=libheif --platform=linux/$(ARCH) --build-arg=LIBHEIF_VERSION=1.17.6 .
-	docker build --target=libheif --platform=linux/$(ARCH) --build-arg=LIBHEIF_VERSION=1.18.0 .
-	docker build --target=libheif --platform=linux/$(ARCH) --build-arg=LIBHEIF_VERSION=1.18.1 .
 	docker build --target=libheif --platform=linux/$(ARCH) --build-arg=LIBHEIF_VERSION=1.18.2 .
+	docker build --target=libheif --platform=linux/$(ARCH) --build-arg=LIBHEIF_VERSION=1.19.8 .
+	docker build --target=libheif --platform=linux/$(ARCH) --build-arg=LIBHEIF_VERSION=1.20.2 .
+	docker build --target=libheif --platform=linux/$(ARCH) --build-arg=LIBHEIF_VERSION=1.21.2 .
 
 test:
 	docker build --target=tested --platform=linux/$(ARCH) .

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # pyheif
-Python 3.6+ interface to [libheif](https://github.com/strukturag/libheif) library using CFFI
+Python interface to [libheif](https://github.com/strukturag/libheif) library using CFFI
 
 *Note*: currently only reading is supported.
 

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ import pyheif
 
 heif_file = pyheif.read("IMG_7424.HEIC")
 image = Image.frombytes(
-    heif_file.mode, 
-    heif_file.size, 
+    heif_file.mode,
+    heif_file.size,
     heif_file.data,
     "raw",
     heif_file.mode,
@@ -139,6 +139,3 @@ The `HeifAuxiliaryImage` has the following properties:
 * `id` - the id of the image
 * `image` - the `UndecodedHeifImage` or `HeifImage` object of the image
 * `type` - a string indicating the type of auxiliary image
-
-
-

--- a/libheif/libheif_api.h
+++ b/libheif/libheif_api.h
@@ -296,6 +296,7 @@ struct heif_color_profile_nclx
   float color_primary_green_x, color_primary_green_y;
   float color_primary_blue_x, color_primary_blue_y;
   float color_primary_white_x, color_primary_white_y;
+  ...;
 };
 
 // Returns 'heif_error_Color_profile_does_not_exist' when there is no NCLX profile.
@@ -356,6 +357,7 @@ struct heif_color_conversion_options
   // Set this field to 'true' if you want to make sure that the specified algorithm is used even
   // at the cost of slightly higher computation times.
   uint8_t only_use_preferred_chroma_algorithm;
+  ...;
 };
 
 
@@ -398,6 +400,7 @@ struct heif_decoding_options
   // version 5 options
 
   struct heif_color_conversion_options color_conversion_options;
+  ...;
 };
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,0 @@
--r requirements-test.txt
-
-black==24.3.0
-pipdeptree==0.13.2
-setuptools==70.0.0

--- a/requirements-publish.txt
+++ b/requirements-publish.txt
@@ -1,4 +1,0 @@
--r requirements-dev.txt
-
-cffi==1.15.0
-twine==3.7.1

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,3 @@
-pytest==6.2.5
-piexif==1.1.3
-Pillow>=9.5.0; implementation_name != "pypy" or python_version != "3.7"
-Pillow==10.3.0; implementation_name == "pypy" and python_version == "3.7"
+pytest>=7
+piexif>=1.1.3
+Pillow>=10.4

--- a/setup.py
+++ b/setup.py
@@ -16,10 +16,10 @@ setup(
     cffi_modules=["libheif/libheif_build.py:ffibuilder"],
     author="Anthony Paes",
     author_email="ant32bit-carsales@users.noreply.github.com",
-    description="Python 3.6+ interface to libheif library",
+    description="Python interface to libheif library",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    python_requires=">= 3.6",
+    python_requires=">= 3.8",
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: Apache Software License",

--- a/tools/freeze-deps.sh
+++ b/tools/freeze-deps.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-pipdeptree -f --warn silence | ggrep -P '^[\w0-9\-=.]+' > requirements-dev.txt
-

--- a/tools/git-push.sh
+++ b/tools/git-push.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-git add -A .
-git commit -a -m "$1"
-git push

--- a/tools/pypi-publish.sh
+++ b/tools/pypi-publish.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-rm dist/*
-python setup.py sdist
-twine upload dist/*


### PR DESCRIPTION
## PR Description

### Summary
This PR refactors the build/test pipeline to make wheel builds faster, more maintainable, and better aligned with current Python/libheif versions.

Key outcomes:
- Migrates the Docker build base from `manylinux2014` to `manylinux_2_28`.
- Splits builds into parameterized single-version runs (one Python + one libheif per build).
- Adds GitHub Actions matrix testing across supported Python and libheif versions.
- Introduces Docker layer caching in CI to speed up repeated runs.
- Simplifies dependency/test/publish tooling by removing legacy helper files/scripts.

### Why
The previous pipeline built and tested many variants inside one Docker build, which was slower and harder to maintain.  
This change moves to matrix-based CI and targeted Docker builds to improve:
- Build reproducibility
- CI performance
- Clarity of failures (exact Python/libheif combo)
- Ongoing version maintenance

### What Changed

#### 1. Dockerfile modernization
- New defaults:
  - `LIBHEIF_VERSION=1.21.2`
  - `PYTHON_VERSION=cp312-cp312`
- Base image updated to `quay.io/pypa/manylinux_2_28:2026.02.06-1`.
- Build tool setup simplified:
  - `nasm` via `dnf`
  - `cmake<4` via `pipx`
- Dependency version bumps:
  - `x265` `3.6` → `4.1`
  - `libde265` `1.0.15` → `1.0.16`
  - `libaom` `v3.8.3` → `v3.13.1`
- Reworked stages:
  - `libheif-deps` → `libheif` → `wheel` → `tested`
- Removes embedded publish stage from Dockerfile; focus is now build + test.

#### 2. CI workflow overhaul (`.github/workflows/test.yml`)
- Adds dedicated `Test` workflow with:
  - `libheif-cache` warmup job (Buildx + GHA cache)
  - Python matrix job (default libheif):
    - `cp38`, `cp39`, `cp310`, `cp311`, `cp312`, `cp313`, `cp314`, `pp311`
  - libheif matrix job (default Python):
    - `1.16.2`, `1.18.2`, `1.19.8`, `1.20.2`, `1.21.2`
- Uses `docker/build-push-action@v6` for cache-aware builds.

#### 3. Makefile improvements
- New configurable vars:
  - `ARCH`, `LIBHEIF_VERSION`, `PYTHON_VERSION`
- `test` now builds one explicit variant at a time.
- New targets:
  - `copy` (extract wheels from built image)
  - `test_libheif_versions`
  - `test_python_versions`
  - `copy_python_versions`

#### 4. Dependency/tooling cleanup
- `requirements-test.txt` updated to modern ranges:
  - `pytest>=7`
  - `piexif>=1.1.3`
  - `Pillow>=10.4`
- Removed obsolete files:
  - `requirements-dev.txt`
  - `requirements-publish.txt`
  - `tools/freeze-deps.sh`
  - `tools/git-push.sh`
  - `tools/pypi-publish.sh`

#### 5. Compatibility resilience in CFFI API definitions
- Added `...;` placeholders in selected structs in `libheif/libheif_api.h` to tolerate libheif struct evolution across versions during CFFI parsing.

#### 6. Minor housekeeping
- `.dockerignore` refined (`.*` → `.git*`).
- README formatting cleanup (no behavioral changes).

### Compatibility / Risk Notes
- Switching to `manylinux_2_28` changes wheel platform baseline compared to `manylinux2014`.
- CI coverage now reflects Python 3.8+ and PyPy 3.11 (older Python/PyPy variants removed from build/test matrix).

### Validation
- CI is designed to validate:
  - Python compatibility matrix (default libheif)
  - libheif compatibility matrix (default Python)
  - Cached rebuild behavior for libheif dependency layer

### Non-goals
- No functional changes to runtime decoding behavior.
- No API feature additions in `pyheif` user-facing interface.